### PR TITLE
Fix type mismatch between String and ID due to Github API update

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const fetchCardsQuery = `query projectCards($owner: String!, $repo: String!, $pr
                            }
                          }`
 
-const archiveCardQuery = `mutation archiveCards($cardId: String!, $isArchived: Boolean = true) {
+const archiveCardQuery = `mutation archiveCards($cardId: ID!, $isArchived: Boolean = true) {
                              updateProjectCard(input:{projectCardId: $cardId, isArchived: $isArchived}) {
                                projectCard {
                                  id


### PR DESCRIPTION
This PR updates the GraphQL mutation to archive a card to use the `ID` type instead of the `String` type.

I was receiving the following error using the current latest commit:

```
archiveCard error:  GraphqlError: Type mismatch on variable $cardId and argument projectCardId (String! / ID!)
    at <redacted>/gh-action-autoarchive-stale-cards-for-column/v1.0/node_modules/@octokit/graphql/dist-node/index.js:69:13
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async <redacted>/gh-action-autoarchive-stale-cards-for-column/v1.0/index.js:116:9 {
  errors: [
    {
      path: [Array],
      extensions: [Object],
      locations: [Array],
      message: 'Type mismatch on variable $cardId and argument projectCardId (String! / ID!)'
    }
  ],
  headers: {<redacted>},
  name: 'GraphqlError',
  request: {
    query: 'mutation archiveCards($cardId: String!, $isArchived: Boolean = true) {\n' +
      '                             updateProjectCard(input:{projectCardId: $cardId, isArchived: $isArchived}) {\n' +
      '                               projectCard {\n' +
      '                                 id\n' +
      '                               }\n' +
      '                             }\n' +
      '                           }',
    variables: { cardId: '<redacted>' },
    headers: {
      authorization: 'bearer ***'
    }
  }
}
```

The `ID` type is documented at [this link](https://docs.github.com/en/graphql/reference/input-objects#updateprojectcardinput).

I do think this was a recent change (this action started failing for us between Feb 18, 2022 and Feb 25, 2022), but I'm unable to find this change documented in the [Github API changelog](https://docs.github.com/en/graphql/overview/changelog#schema-changes-for-2022-02-28).

In any case, this new code works for us, and if you'd like to test this yourself and merge at some point, that would be great.